### PR TITLE
Upgrade jackson version and revert logback classic to 1.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <junit.version>4.13.2</junit.version>
-        <logback.version>1.4.4</logback.version>
+        <logback.version>1.3.5</logback.version>
         <resource-server.version>1.3.1</resource-server.version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.36</slf4j.version>
@@ -48,7 +48,7 @@
         <jdbc.version>2.5.0</jdbc.version>
 
         <!-- Utility libraries -->
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 


### PR DESCRIPTION
updated to the most recent jackson version, but reverted back to logback classic v1.3.5 