### PR TITLE
fix: address logging issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,13 +9,16 @@ on:
 
 jobs:
   test:
-    name: "${{ matrix.platform }} with Java 8"
+    name: "${{ matrix.platform }} with Java ${{ matrix.java-version }}"
     strategy:
       matrix:
         platform:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java-version:
+          - 8
+          - 11
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 10
     steps:
@@ -25,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: ${{ matrix.java-version }}
       - name: Test
         run: mvn -B test
       - name: Checkstyle

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <logback.version>1.3.5</logback.version>
         <resource-server.version>1.3.1</resource-server.version>
         <servlet-api.version>3.1.0</servlet-api.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
         <spring.version>4.3.30.RELEASE</spring.version>
 
         <!-- The JDBC Driver used by the portlet -->
@@ -142,6 +142,12 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -191,6 +197,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-tools</artifactId>
             <version>3.6.0.Final</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency><!-- java bytecode processor required by hibernate-->
@@ -709,6 +721,41 @@
                         </goals>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>log4j:*</exclude>
+                                        <exclude>commons-logging:*</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
During Java 11 upgrade testing, it was found that logging was not working as there was no logging file for this portlet.
The fix is to use SLF4J version 2.0.x, which works with Logback 3.5.x.
(Alternatively, you could use SLF4J 1.7.x with Logback 2.11.x)
Also added updates to prevent log4j and commons-logging jars from getting added.