### PR TITLE
fix: replace "new Boolean()" with autoboxing for compatibility with n…

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/model/Role.java
+++ b/src/main/java/org/jasig/portlet/announcements/model/Role.java
@@ -44,7 +44,7 @@ public class Role {
    */
   public Role(String name, boolean selected) {
     this.name = name;
-    this.selected = new Boolean(selected);
+    this.selected = selected;
   }
 
   /**


### PR DESCRIPTION
…ew Java versions.

Boolean constructor has been deprecated in Java 21 and will be removed in future versions.