### PR TITLE
chore(ci): upgrade github actions test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,27 +28,34 @@ on:
 
 jobs:
   test:
-    name: "${{ matrix.platform }} with Java ${{ matrix.java-version }}"
+    name: '${{ matrix.platform }} with Java ${{ matrix.java-distribution }} version ${{ matrix.java-version }}'
     strategy:
       matrix:
         platform:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        java-distribution:
+          - adopt-hotspot
+          - temurin
+          - zulu
         java-version:
           - 8
           - 11
+        include:
+          - platform: windows-latest
+            java-distribution: adopt-hotspot
+            java-version: 11
+          - platform: macos-latest
+            java-distribution: adopt-hotspot
+            java-version: 11
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
-      - name: Test
-        run: mvn -B test
-      - name: Checkstyle
-        run: mvn -B checkstyle:check --fail-never
+      - name: Build and Test
+        run: mvn -B package


### PR DESCRIPTION
Update CI to use checkout@v4 and setup-java@v4 for Build and Test